### PR TITLE
Fix fastboot detection

### DIFF
--- a/addon/services/is-mobile.js
+++ b/addon/services/is-mobile.js
@@ -23,7 +23,7 @@ export default class IsMobileService extends Service {
 
     let tests;
 
-    if (this.fastboot.isFastBoot) {
+    if (this.fastboot !== undefined && this.fastboot.isFastBoot) {
       let headers = this.fastboot.request.headers;
       let userAgent = headers.headers['user-agent'];
 


### PR DESCRIPTION
Fixes an issue where ember-is-mobile will fail to run if the fastboot plugin is not installed.

In commit a9ce51a7a51920f5d4169061dae2d7b6f98bf75f the old Ember.get syntax was removed. However this also accidentally removed the implicit check for `this.fastboot` being undefined. This PR checks that this.fastboot is defined before checking `isFastboot`